### PR TITLE
feat: add NBT-aware item fetching in listings

### DIFF
--- a/src/lib/components/widgets/shops/cards/ItemCard.svelte
+++ b/src/lib/components/widgets/shops/cards/ItemCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import Button from '$lib/components/ui/Button.svelte';
 	import {
 		canBuyListing,
 		getItemImageUrl,
@@ -6,7 +7,6 @@
 		type ItemListing
 	} from '$lib/stores/shopsync';
 	import type { Listing } from '$lib/types/shops';
-	import Button from '$lib/components/ui/Button.svelte';
 	import ItemBadges from '../ItemBadges.svelte';
 
 	const {
@@ -65,7 +65,12 @@
 		{/if}
 
 		{#if showViewLink}
-			<Button variant="primary" href="/shops/items/{item.itemName.replace(/:/g, '/')}">
+			<Button
+				variant="primary"
+				href="/shops/items/{item.itemName.replace(/:/g, '/')}{item.itemNbt
+					? `?nbt=${encodeURIComponent(item.itemNbt)}`
+					: ''}"
+			>
 				View Item
 			</Button>
 		{/if}

--- a/src/lib/stores/shopsync.ts
+++ b/src/lib/stores/shopsync.ts
@@ -125,12 +125,19 @@ export const getListingsByItem = (shops: FetchedStoreData<Shop>): ItemListing[] 
 	return listings;
 };
 
-export const getListing = (itemName: string, modId?: string): ItemListing | null => {
+export const getListing = (itemName: string, modId?: string, nbt?: string | null): ItemListing | null => {
 	if (modId) {
 		itemName = modId + ':' + itemName;
 	}
 	const allListings = getListingsByItem(get(store));
-	return allListings.find((x) => x.itemName === itemName) ?? null;
+
+	const requiresNbt = itemsRequiringNbt.includes(itemName.toLowerCase());
+	const listing = allListings.find(
+		(x) =>
+			x.itemName === itemName &&
+			(!requiresNbt || x.itemNbt === nbt)
+	);
+	return listing ?? null;
 };
 
 export default store;

--- a/src/routes/shops/items/[modid]/[itemname]/+page.svelte
+++ b/src/routes/shops/items/[modid]/[itemname]/+page.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
+	import Section from '$lib/components/ui/Section.svelte';
 	import ModuleLoading from '$lib/components/widgets/other/ModuleLoading.svelte';
+	import ShopCard from '$lib/components/widgets/shops/cards/ShopCard.svelte';
+	import ItemBadges from '$lib/components/widgets/shops/ItemBadges.svelte';
 	import {
 		cleanShopData,
 		getItemImageUrl,
@@ -8,20 +12,20 @@
 		type ItemListing,
 		type ShopWithListing
 	} from '$lib/stores/shopsync';
-	import { onMount } from 'svelte';
 	import { formatCurrency } from '$lib/util';
-	import Section from '$lib/components/ui/Section.svelte';
-	import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
 	import { faShop } from '@fortawesome/free-solid-svg-icons';
-	import ShopCard from '$lib/components/widgets/shops/cards/ShopCard.svelte';
-	import ItemBadges from '$lib/components/widgets/shops/ItemBadges.svelte';
+	import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
+	import { onMount } from 'svelte';
 
 	const { params } = $props();
+	const { url } = page;
+
+	const nbt = url.searchParams.get('nbt');
 
 	let item = $state<ItemListing | null>(null);
 
 	onMount(() => {
-		item = getListing(params.itemname, params.modid);
+		item = getListing(params.itemname, params.modid, nbt);
 		if (!item) {
 			goto('/shops/items?error=not-found');
 		}


### PR DESCRIPTION
### Summary
This PR updates the item fetching logic to correctly handle NBT data in listings.

### Changes
- Modified `getListing` to accept an optional `nbt` parameter.
- Added conditional matching when `itemsRequiringNbt` includes the item.
- Updated pages to pass through `nbt` from `url.searchParams`.